### PR TITLE
Support second endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,91 @@
+# http://www.gnu.org/software/automake
+
+Makefile.in
+
+# http://www.gnu.org/software/autoconf
+
+autom4te.cache
+aclocal.m4
+compile
+configure
+depcomp
+install-sh
+missing
+stamp-h1
+
+config.guess
+config.sub
+ltmain.sh
+
+build
+*.json
+
+# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
+#
+# * Create a file at ~/.gitignore
+# * Include files you want ignored
+# * Run: git config --global core.excludesfile ~/.gitignore
+#
+# After doing this, these files will be ignored in all your git projects,
+# saving you from having to 'pollute' every project you touch with them
+#
+# For MacOS:
+#
+.DS_Store
+
+# ignore RVM configuration
+.rvmrc
+
+# For TextMate
+*.tmproj
+tmtags
+
+# For emacs:
+*~
+\#*
+.\#*
+
+# For vim:
+*.swp
+
+# For redcar:
+.redcar
+
+# For rubinius:
+*.rbc
+
+# standard C++ Git igore
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+*.pcm
+*_Dict.cc
+*.status
+
+# Executables
+*.exe
+*.out
+*.app
+/.cproject
+/.project

--- a/dam_plugin.cc
+++ b/dam_plugin.cc
@@ -65,6 +65,21 @@ int dam_plugin::create_device(deviceblock *db)
 						  npackets));
 	  return 0;  // say "we handled this request" 
 	}
+      else if ( db->npar == 7)
+	{
+	  int trigger = get_value ( db->argv3);
+	  int nunits = get_value ( db->argv4);
+	  int npackets = get_value ( db->argv5);
+	  std::string devName = ( db->argv6);
+
+	  add_readoutdevice ( new daq_device_dam( eventtype,
+						  subid,
+						  trigger,
+						  nunits,
+						  npackets,
+						  devName));
+	  return 0;  // say "we handled this request" 
+	}
 
       else
 	{

--- a/daq_device_dam.cc
+++ b/daq_device_dam.cc
@@ -29,6 +29,7 @@ daq_device_dam::daq_device_dam(const int eventtype
 			       , const int trigger
 			       , const int nunits
 			       , const int npackets
+             , const std::string & damDevName
 			       )
 {
 
@@ -39,6 +40,7 @@ daq_device_dam::daq_device_dam(const int eventtype
   _nunits = nunits;     // how much we cram into one packet
   _npackets = npackets;  // how many packet we make
   _broken = 0;
+  m_deviceName = damDevName;
 
   if ( _nunits <= 0) _nunits = 1;
   if ( _npackets <= 0) _npackets = 1;
@@ -89,7 +91,7 @@ int  daq_device_dam::init()
     }
 
   _broken = 0;
-  pl_open(&_dam_fd);
+  pl_open(&_dam_fd, m_deviceName.c_str());
 
   if ( _dam_fd < 0)
     {
@@ -199,7 +201,7 @@ void daq_device_dam::identify(std::ostream& os) const
 {
   if ( _broken) 
     {
-      os << "FELIX DAM Card  Event Type: " << m_eventType 
+      os << "FELIX DAM Card "<<m_deviceName<<" Event Type: " << m_eventType 
 	 << " Subevent id: " << m_subeventid 
 	 << " payload units " << _nunits 
 	 << " packets " << _npackets 
@@ -207,7 +209,7 @@ void daq_device_dam::identify(std::ostream& os) const
     }
   else
     {
-      os << "FELIX DAM Card  Event Type: " << m_eventType 
+      os << "FELIX DAM Card "<<m_deviceName<<" Event Type: " << m_eventType 
 	 << " Subevent id: " << m_subeventid 
 	 << " payload units " << _nunits 
 	 << " packets " << _npackets;

--- a/daq_device_dam.cc
+++ b/daq_device_dam.cc
@@ -11,7 +11,9 @@
 #include "pl_lib.h"
 //#include "fee_reg.h"
 
-#define DATA_LENGTH          137*256 // 137 words * 256 channels
+// DAM transmit 256 bit word. 
+// This byte-unit length is just and large chunk of multiple of 256 bits
+#define DATA_LENGTH          256*256 
 #define FEE_SAMPA_CTRL       0x5
 #define DAM_DMA_FIFO         0x5
 #define DAM_DMA_CTRL         0x4004
@@ -177,20 +179,19 @@ int daq_device_dam::put_data(const int etype, int * adr, const int length )
       sevt->reserved[0] = 0;
       sevt->reserved[1] = 0;
 
+      // DAM IO uses unistd read(), which operates on the byte length units
+      uint8_t *dest = (uint8_t *) &sevt->data;
 
-      uint16_t *dest = (uint16_t *) &sevt->data;
+      ssize_t  c = read(_dam_fd, dest, _length);
+      // cout << __LINE__ << "  " << __FILE__ << " read  "  << c << " bytes " << endl;
 
-      int ret;
-  
-      ret = read(_dam_fd, dest, _length);
+      // padding to 8 bytes
+      sevt->sub_padding = c%8;
+      if ( sevt->sub_padding) sevt->sub_padding = 8 - sevt->sub_padding;
 
-      //cout << __LINE__ << "  " << __FILE__ << " read  "  << ret << " words " << endl;
-      
-      //      sevt->sub_padding = ret%2 ;
-      sevt->sub_padding = 0;  // we can never have an odd number of uint16s
-  
-      sevt->sub_length += (ret + sevt->sub_padding);
-      // cout << __LINE__ << "  " << __FILE__ << " returning "  << sevt->sub_length << endl;
+      sevt->sub_length += (c + sevt->sub_padding) /4;
+      // cout << __LINE__ << "  " << __FILE__ << " sevt->sub_padding =  "  << sevt->sub_padding << " return add  " << (c + sevt->sub_padding) /4 << endl;
+
       overall_length += sevt->sub_length;
     }
   return overall_length;

--- a/daq_device_dam.h
+++ b/daq_device_dam.h
@@ -5,6 +5,7 @@
 #include <daq_device.h>
 #include <stdio.h>
 #include <damTriggerHandler.h>
+#include <string>
 
 class Fee;
 
@@ -17,7 +18,9 @@ public:
 		 , const int subeventid
 		 , const int trigger = 1
 		 , const int nunits=1
-		 , const int npackets=1);
+		 , const int npackets=1
+     , const std::string & damDevName = "/dev/dam0"
+     );
 
   ~daq_device_dam();
 
@@ -35,7 +38,6 @@ public:
   int rearm( const int etype);
   
   int endrun();
-
   
  protected:
 
@@ -51,7 +53,7 @@ public:
   
   damTriggerHandler *_th;
 
-
+  std::string m_deviceName;
 };
 
 

--- a/pl_lib.c
+++ b/pl_lib.c
@@ -44,8 +44,8 @@ int dam_wait_for_dma(int fd, int *data)
     return 0;
 }
 
-int pl_open(int *fd) {
-    if ( (*fd = open(DEVNAME, O_RDWR)) <= 0 ) {
+int pl_open(int *fd, const char * dev_name) {
+    if ( (*fd = open(dev_name, O_RDWR)) <= 0 ) {
         perror(__func__);
         return -1;
     }

--- a/pl_lib.h
+++ b/pl_lib.h
@@ -7,10 +7,9 @@ extern "C" {
 
 #include "dam_ioctl.h"
 
-#define DEVNAME "/dev/dam0"
 #define PAGE_SIZE 4096
 
-int pl_open(int *fd);
+int pl_open(int *fd, const char * dev_name);
 int pl_close(int fd);
 uint32_t pl_register_read(int fd, uint32_t addr);
 int pl_register_write(int fd, uint32_t addr, uint32_t data);


### PR DESCRIPTION
Add support second endpoint as used in the data pipeline bottleneck study: 
https://sphenix-intra.sdcc.bnl.gov/WWW/elog/TPC/97

It adds to server simply with 
```bash
rcdaq_client create_device device_dam 1 4${H:4:2}0 1 1 1 /dev/dam0
rcdaq_client create_device device_dam 1 4${H:4:2}1 1 1 1 /dev/dam1
```
for `~phnxrc/operations/TPC/rcdaq_setup_tpc_generic.sh`